### PR TITLE
docs: add how-it-works overview and expand troubleshooting guide

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,3 +16,15 @@ TangCore is a comprehensive FPGA gaming distribution that brings classic gaming 
 - **MDTang** - Sega Genesis/Mega Drive
 - **SMSTang** - Sega Master System
 
+## How TangCore Works
+
+A TangCore board has two chips working together: a **BL616 MCU** (the "system manager") and a **Gowin FPGA** (the console itself).
+
+1. **Power on**: the BL616 runs the TangCore firmware. It reads `cores/<your_board>/monitor.bin` from the SD card or USB drive, and programs the FPGA with it over JTAG. This is the "menu core" and takes about 5-7 seconds. If a core file cannot be found on the drive, the menu shows **N/A** for that system.
+2. **Launching a game**: when you pick a ROM in the menu, the BL616 re-programs the FPGA with the corresponding core (e.g. `nestang.bin`) - at that moment the FPGA literally becomes an NES/SNES/GBA in hardware - then streams the ROM file into the core's memory over a fast UART link.
+3. **While playing**: controller input and the in-game overlay menu are also handled by the BL616 and forwarded to the core over the same link.
+
+Because cores are loaded into FPGA SRAM (not flash), core switching is fast and does not wear anything out. It also means the SD card / USB drive must stay inserted while playing.
+
+The **BOOT button** on the board serves a different purpose: holding it while connecting USB puts the BL616 into its bootloader, which is only used for flashing the TangCore firmware itself with Bouffalo Flash Cube. In this mode the firmware does not run, so the screen stays at the TangCore logo and no menu appears.
+

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -1,5 +1,13 @@
 # Troubleshooting
 
+## The menu shows "N/A" for every core
+
+The firmware could not find the core bitstreams on your SD card / USB drive. Make sure the drive contains the `cores` directory from the release package, so that files like `/cores/console60k/nestang.bin` exist for your board model. Also see "The on-board SD card slot is not detected" below.
+
+## The screen is stuck at the TangCore logo
+
+If you held the BOOT button while connecting power/USB, the BL616 MCU is in bootloader (firmware flashing) mode and the TangCore firmware does not run. This mode is only needed for flashing firmware with Bouffalo Flash Cube. Reconnect power without holding BOOT to boot normally.
+
 ## There's no video output
 
 Check the following,
@@ -23,4 +31,24 @@ If you use USB controllers,
 
 * Only the Sipeed-provided USB gamepads can be used with the on-board USB-A port. If it is not recognized, replug the pad.
 * Other types of USB gamepads needs a USB hub to work. Please follow instructions on the [controllers page](controllers.md).
+
+## My ROM does not load ("Only .nes supported" and similar messages)
+
+ROM files must be uncompressed. `.zip` files are not supported - extract them first. Each system only accepts its own extensions: `.nes` (NES), `.smc`/`.sfc` (SNES), `.gba` (GBA), `.bin`/`.md` (Genesis), `.sms` (SMS), `.img` (PC/XT floppy images).
+
+## File names show up garbled in the menu
+
+Non-ASCII file names (Chinese, Japanese, accented characters and so on) are not supported by the menu. Rename your ROM files using only ASCII letters, numbers and punctuation.
+
+## Strange `._xxx` files appear in the file browser (macOS)
+
+macOS creates hidden AppleDouble (`._*`) and Spotlight index files on removable drives. They are harmless but clutter the file list. Before ejecting the drive on macOS, clean them up:
+
+```bash
+dot_clean -m /Volumes/<your_drive> && find /Volumes/<your_drive> -name '._*' -delete
+```
+
+## The on-board SD card slot is not detected
+
+The on-board SD card slot is only supported on Tang Console **v1.1** boards (since TangCore 0.9). On earlier boards, put the SD card in a USB card reader (or use a USB drive) and connect it through the USB-C OTG adapter instead.
 


### PR DESCRIPTION
## Summary

While setting up TangCore 0.9 on a brand-new Tang Console 60K, I ran into several issues that were not covered by the docs. This PR adds them, based on the firmware source and my own debugging:

**`docs/index.md`** - new "How TangCore Works" section for end users:
- BL616 (system manager) vs FPGA (console) split
- monitor.bin / core loading over JTAG into FPGA SRAM, ROM streaming over UART
- why the menu shows "N/A" when core files are missing
- what the BOOT button actually does (bootloader mode, stuck-at-logo behavior)

**`docs/user-guide/troubleshooting.md`** - new entries:
- Menu shows "N/A" for every core (missing `cores/` on the drive)
- Screen stuck at TangCore logo (BOOT held during power-on)
- ROMs not loading: `.zip` not supported, per-system extension list (from `core/*.cpp` extension checks)
- Non-ASCII (e.g. Chinese) file names garbled in the menu
- macOS AppleDouble `._*` junk files cluttering the file browser, with a `dot_clean` one-liner
- On-board SD slot only working on Tang Console v1.1 boards

Happy to adjust wording or drop any entry you feel doesn't belong.

Made with [Cursor](https://cursor.com)